### PR TITLE
AbstractModuleNoTrait's use of glob() must handle false return value

### DIFF
--- a/src/Payum/PayumModule/Module/AbstractModuleNoTraits.php
+++ b/src/Payum/PayumModule/Module/AbstractModuleNoTraits.php
@@ -83,6 +83,10 @@ abstract class AbstractModuleNoTraits implements
                 GLOB_BRACE
         );
 
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
+
         $config = array();
         foreach ($configFiles as $configFile) {
             $config = ArrayUtils::merge($config, include $configFile);
@@ -102,6 +106,10 @@ abstract class AbstractModuleNoTraits implements
                 $this->getDir() . '/' . $this->relativeModuleDir . 'config/service/controller.config{,.*}.php',
                 GLOB_BRACE
         );
+
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
 
         $config = array();
         foreach ($configFiles as $configFile) {
@@ -123,6 +131,10 @@ abstract class AbstractModuleNoTraits implements
                 GLOB_BRACE
         );
 
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
+
         $config = array();
         foreach ($configFiles as $configFile) {
             $config = ArrayUtils::merge($config, include $configFile);
@@ -142,6 +154,10 @@ abstract class AbstractModuleNoTraits implements
                 $this->getDir() . '/' . $this->relativeModuleDir . 'config/service/viewhelper.config{,.*}.php',
                 GLOB_BRACE
         );
+
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
 
         $config = array();
         foreach ($configFiles as $configFile) {


### PR DESCRIPTION
The glob() function we use for finding config files can return "false" on some platforms instead of an empty array when no files are found. This was causing an error in the foreach statement on these platforms. False is now transformed to an empty array to avoid this.

Note that glob() also returns "false" in an error case - unfortunately this does mean we can't tell the difference between no files found and an error in the glob() function.  In either case we treat it as if no files were found.
