### PR TITLE
Fixed the readme '$payum_id does not exist

### DIFF
--- a/docs/get-it-started.md
+++ b/docs/get-it-started.md
@@ -15,6 +15,7 @@ use Payum\Core\Model\ArrayObject;
 
 class PaymentDetails extends \ArrayObject
 {
+    protected $payum_id;
 }
 ```
 


### PR DESCRIPTION
The readme missed the `$payum_id` property ..

```
Property Application\Model\PaymentDetails::$payum_id does not exist
```
