### PR TITLE
Use classic array declaration instead of the short one

### DIFF
--- a/src/Payum/PayumModule/Registry/RegistryFactory.php
+++ b/src/Payum/PayumModule/Registry/RegistryFactory.php
@@ -19,7 +19,7 @@ class RegistryFactory implements FactoryInterface
         $registry = new ServiceLocatorAwareRegistry(
             $options->getGateways(),
             $options->getStorages(),
-            []
+            array()
         );
         
         //TODO: quick fix. we should avoid early init of services. has to be reworked to be lazy


### PR DESCRIPTION
Use this notation to be compatible with php >=5.3.3